### PR TITLE
Updating the Opeshift Rest Client to 0.3.0

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,7 @@
     "prefer-const": "error",
     "block-scoped-var": "error",
     "prefer-template": "warn",
+    "no-unneeded-ternary": "warn",
     "no-use-before-define": [
       "error",
       "nofunc"

--- a/README.md
+++ b/README.md
@@ -106,6 +106,20 @@ The `.nodeshift` directory is responsible for holding your resource files.  Thes
 
 Currently, nodeshift will only create resources based on the files specified,  in the future, its possible somethings could be created by default
 
+### Advanced Options
+
+There are a few options available on the CLI or when using the API
+
+        Usage: nodeshift [--options]
+
+        Options:
+        --projectLocation <project directory location>       change the default location of the project
+        --configLocation <configuration directory location>  change the default location of the config
+        --nodeshiftDirectory <nodeshift directory name>      change the default name of the directory nodeshift looks at for resource files
+        --osc.strictSSL [value]                              setting to pass to the Openshift Rest Client. Set to false if using a self-sign cert
+
+Of course, there is also the standard `-V` and `--help` options for version and help
+
 ## Contributing
 
 Please read the [contributing guide](./CONTRIBUTING.md)

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -13,7 +13,8 @@ program
   .usage('[--options]')
   .option('--projectLocation <project directory location>', 'change the default location of the project')
   .option('--configLocation <configuration directory location>', 'change the default location of the config')
-  .option('--nodeshiftDirectory <nodeshift directory name>', 'change the default name of the directory nodeshift looks at for resource files');
+  .option('--nodeshiftDirectory <nodeshift directory name>', 'change the default name of the directory nodeshift looks at for resource files')
+  .option('--osc.strictSSL [value]', 'setting to pass to the Openshift Rest Client. Set to false if using a self-sign cert');
 
 program.parse(process.argv);
 
@@ -22,5 +23,8 @@ const options = {};
 options.projectLocation = program.projectLocation;
 options.configLocation = program.configLocation;
 options.nodeshiftDirectory = program.nodeshiftDirectory;
+options.osc = {
+  strictSSL: (program['osc.strictSSL'] === 'false') ? false : true
+};
 
 cli(options);

--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -56,7 +56,11 @@ function setup (options) {
   // Load the config
   return openshiftConfigLoader(options.configLocation).then(config => {
     // Also need to load the openshft rest client library
-    return openshiftRestClient(config).then(osc => {
+    const settings = {
+      request: options.osc
+    };
+
+    return openshiftRestClient(config, settings).then(osc => {
       // Return a new object with the config, the rest client and other data. TODO: add metadata, label defaults
       return Object.assign({}, config, {projectName: projectName, projectVersion: projectVersion, buildName: buildName, openshiftRestClient: osc}, options);
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -2511,9 +2511,9 @@
       "integrity": "sha1-pB9+/LWVYe74QzU6F/cKU2pxSqg="
     },
     "openshift-rest-client": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/openshift-rest-client/-/openshift-rest-client-0.2.0.tgz",
-      "integrity": "sha1-Uajk7XNxL+TEbH3anN4qV3SKG8Y="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/openshift-rest-client/-/openshift-rest-client-0.3.0.tgz",
+      "integrity": "sha1-3657OMWojLPR7nGkM5x8Z/lMKVw="
     },
     "optimist": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lodash": "^4.17.4",
     "mkdirp": "^0.5.1",
     "openshift-config-loader": "^0.1.1",
-    "openshift-rest-client": "^0.2.0",
+    "openshift-rest-client": "^0.3.0",
     "request": "^2.81.0",
     "rimraf": "^2.6.1",
     "tar": "^3.1.3"


### PR DESCRIPTION
* Adds an option '--osc.strictSSL' which gets passed to the Openshift rest client. switch to false if using a self-signed cert
* can also be passed in as an option when using the API 'options.osc.strictSSL'

connects to #29