### PR TITLE
Handle more than just a Complete build status

### DIFF
--- a/lib/binary-build.js
+++ b/lib/binary-build.js
@@ -44,6 +44,12 @@ module.exports = (config, archiveLocation) => {
             console.log('Build finished');
             return resolve(buildStatus);
           }
+
+          if (buildStatus.status.phase === 'Failed') {
+            clearInterval(internvalId);
+            console.log('Build Failed with message:', buildStatus.status.message);
+            return reject(new Error(buildStatus.status.message));
+          }
         });
       }, 2000);
     });


### PR DESCRIPTION
* The interval that checks to see if the build has completed will now check if there is a Failed Status
* A Failed status will then clear the interval and Reject that promise, which will Stop the whole process

for #8