### PR TITLE
fix: increase build wait times linearly

### DIFF
--- a/lib/binary-build.js
+++ b/lib/binary-build.js
@@ -23,9 +23,9 @@ module.exports = async (config, archiveLocation) => {
   const buildLogWatcher = watchBuildLog(config, response.metadata.name);
 
   logger.info('waiting for build to finish');
-  const MAX_RETRIES = 10;
+  const MAX_RETRIES = 200;
   for (let i = 0; i <= MAX_RETRIES; i++) {
-    const timeout = Math.pow(2, i + 8);
+    const timeout = (i + 1) * 200;
     await wait(timeout);
 
     const buildStatus = await config.openshiftRestClient.builds.find(response.metadata.name);


### PR DESCRIPTION
When exponentially increasing the wait times, they can get really really long after a while. Linear time increase by 200ms for each loop makes more sense. We'll end up with several initial checks that will certainly fail the first few times through the loop, no matter how fast the local host is. But when working with openshift online, this approach seems to work better.

Fixes: #60 
Connects to: #60 