### PR TITLE
fix: container image name should be the project name

### DIFF
--- a/lib/definitions/container.js
+++ b/lib/definitions/container.js
@@ -10,7 +10,7 @@ module.exports = (resource, config) => {
   }
 
   const container = {
-    image: config.dockerImageRepo,
+    image: config.projectName,
     name: config.projectName,
     securityContext: {
       privileged: false


### PR DESCRIPTION
I noticed that in the code that puts together the deployment config, for the container image, i was using the docker image repo as the name, which was something like this:  "172.30.1.1:5000/namespace/project-name" instead of just the project-name

everything still works, so i'm not sure why i had that like that before