### PR TITLE
fix: Template parameters should be inline with the openshift templates.

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,32 @@ The `.nodeshift` directory is responsible for holding your resource files.  Thes
 
 Currently, nodeshift will only create resources based on the files specified,  in the future, its possible somethings could be created by default
 
+#### Template Parameters
+
+Some templates might need to have a value set at "run time".  For example, in the template below, we have the `${SSO_AUTH_SERVER_URL}` parameter:
+
+        apiVersion: v1
+        kind: Deployment
+        metadata:
+            name: nodejs-rest-http-secured
+        spec:
+          template:
+            spec:
+              containers:
+                - env:
+                  - name: SSO_AUTH_SERVER_URL
+                    value: "${SSO_AUTH_SERVER_URL}"
+                  - name: REALM
+                    value: master
+
+To set that using nodeshift, use the `-d` option with a KEY=VALUE, like this:
+
+    nodeshift -d SSO_AUTH_SERVER_URL=https://sercure-url
+
+__note that we left off the "${}" on the key,  nodeshift knows to search for a key with ${} added back on__
+
+For more on writing openshift templates, [see here](https://docs.openshift.org/latest/dev_guide/templates.html#writing-templates)
+
 ### Advanced Options
 
 There are a few options available on the CLI or when using the API

--- a/lib/resource-loader.js
+++ b/lib/resource-loader.js
@@ -21,8 +21,9 @@ function loadYamls (resourceList, config) {
         // Do i parse the result here? or should i wait?
         const jsonYaml = helpers.yamlToJson(data);
         const stringJSON = JSON.stringify(jsonYaml);
+        /* eslint prefer-template: "off" */
         const reduced = config.definedProperties.reduce((acc, curr) => {
-          return acc.split(curr.key).join(curr.value);
+          return acc.split('${' + curr.key + '}').join(curr.value);
         }, stringJSON);
         const backToJSON = JSON.parse(reduced);
         return resolve(backToJSON);

--- a/test/resource-loader-test.js
+++ b/test/resource-loader-test.js
@@ -145,12 +145,13 @@ test.skip('test error reading file from list', (t) => {
   });
 });
 
+/* eslint no-template-curly-in-string: "off" */
 test('test string substitution', (t) => {
   const mockedHelper = {
     yamlToJson: (file) => {
       return {
         templates: {
-          SSO_AUTH_SERVER_URL: '{SSO_AUTH_SERVER_URL}'
+          SSO_AUTH_SERVER_URL: '${SSO_AUTH_SERVER_URL}'
         }
       };
     }
@@ -175,7 +176,7 @@ test('test string substitution', (t) => {
   const config = {
     projectLocation: process.cwd(),
     nodeshiftDirectory: '.nodeshift',
-    definedProperties: [{key: '{SSO_AUTH_SERVER_URL}', value: 'https://yea'}]
+    definedProperties: [{key: 'SSO_AUTH_SERVER_URL', value: 'https://yea'}]
   };
 
   resourceLoader(config).then((resourceList) => {


### PR DESCRIPTION
A small change, but it is important.

Templates should now use the `${KEY}` for parameters

and nodeshift users should do `nodeshift -d KEY=VALUE` 

connects to #103 