### PR TITLE
update: add a default revision history limit for deployments.

### DIFF
--- a/lib/definitions/deployment-config-spec.js
+++ b/lib/definitions/deployment-config-spec.js
@@ -5,6 +5,7 @@
 const podTemplateSpec = require('./pod-template-spec');
 
 const REPLICAS = 1;
+const REVISION_HISTORY_LIMIT = 2;
 
 module.exports = (resource, config) => {
   if (!resource.spec) {
@@ -12,6 +13,10 @@ module.exports = (resource, config) => {
   }
   // Apply Replica Count
   resource.spec.replicas = REPLICAS;
+
+  // apply revision history limit, defaulting to 2, which will keep 3
+  resource.spec.revisionHistoryLimit = REVISION_HISTORY_LIMIT;
+
   // Apply selectors
   resource.spec.selector = {
     app: config.projectName,

--- a/test/definitions-tests/deployment-config-spec-test.js
+++ b/test/definitions-tests/deployment-config-spec-test.js
@@ -1,0 +1,39 @@
+'use strict';
+
+const test = require('tape');
+const proxyquire = require('proxyquire');
+
+const deploymentConfigSpec = proxyquire('../../lib/definitions/deployment-config-spec', {
+  './pod-template-spec': (resource, config) => { return resource; }
+});
+
+test('deployment-config-spec test', (t) => {
+  const resource = {};
+  const config = {
+    projectName: 'project1',
+    namespace: 'project-namespace'
+  };
+  const configSpec = deploymentConfigSpec(resource, config);
+
+  t.equal(typeof deploymentConfigSpec, 'function', 'should export a function');
+  t.ok(configSpec.spec, 'should have a spec property');
+  t.equal(configSpec.spec.replicas, 1, 'should have 1 replica');
+  t.equal(configSpec.spec.revisionHistoryLimit, 2, 'should have a value of 2');
+
+  t.equal(configSpec.spec.selector.app, config.projectName, 'should equal the config.projectname');
+  t.equal(configSpec.spec.selector.project, config.projectName, 'should equal the config.projectname');
+  t.equal(configSpec.spec.selector.provider, 'nodeshift', 'should equal nodeshift');
+
+  t.equal(Array.isArray(configSpec.spec.triggers), true, 'this should be an array');
+  t.equal(configSpec.spec.triggers[0].type, 'ConfigChange', 'first trigger should be a config change');
+  t.equal(configSpec.spec.triggers[1].type, 'ImageChange', 'second trigger should be a image change');
+  t.equal(configSpec.spec.triggers[1].imageChangeParams.from.name, `${config.projectName}:latest`, `image name should be ${config.projectName}:latest`);
+  t.end();
+});
+
+test('depoyment spec pass in ', (t) => {
+  const configSpec = deploymentConfigSpec({spec: {}}, {});
+
+  t.ok(configSpec.spec, 'should have a spec property');
+  t.end();
+});


### PR DESCRIPTION
value is set at 2, which will keep the last 3 replication controllers

fixes #118 

connects to #118 