### PR TITLE
Remove nodeshiftdir option

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ There are a few options available on the CLI or when using the API
             --version             Show version number                            [boolean]
             --projectLocation     change the default location of the project      [string]
             --configLocation      change the default location of the config       [string]
-            --nodeshiftDirectory  change the default name of the directory nodeshift looks
-                                    at for resource files                           [string]
             --osc.strictSSL       setting to pass to the Openshift Rest Client. Set to
                                     false if using a self-sign cert
             --nodeVersion, -n     the version of Node.js to use for the deployed

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -24,10 +24,6 @@ yargs
     describe: 'change the default location of the config',
     type: 'string'
   })
-  .options('nodeshiftDirectory', {
-    describe: 'change the default name of the directory nodeshift looks at for resource files',
-    type: 'string'
-  })
   .options('osc.strictSSL', {
     describe: 'setting to pass to the Openshift Rest Client. Set to false if using a self-sign cert'
   })
@@ -72,7 +68,6 @@ function createOptions (argv) {
 
   options.projectLocation = argv.projectLocation;
   options.configLocation = argv.configLocation;
-  options.nodeshiftDirectory = argv.nodeshiftDirectory;
   options.nodeVersion = argv.nodeVersion;
   process.env['NODESHIFT_QUIET'] = argv.quiet === true;
   options.build = argv.build;

--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -11,7 +11,6 @@ const restClient = require('openshift-rest-client');
 
   @param {object} [options] -
   @param {string} [options.projectLocation] - the location(directory) of your projects package.json. Defaults to `process.cwd`
-  @param {string} [options.nodeshiftDirectory] - the location(directory) of your resource files, defaults to the ".nodeshift" directory in your projects location
   @param {string} [options.configLocation] - the location of the openshift/kube config to be passed to the config loader module. defaults to ~/.kube/config
   @param {object} [options.osc] - Overrides for the Openshift Rest Clients request module
   @param {object} [options.osl] - Overrides for the Openshift Config Loader
@@ -26,7 +25,7 @@ const restClient = require('openshift-rest-client');
       Any options you have passed in are added to the config object
 */
 async function setup (options = {}) {
-  options.nodeshiftDirectory = options.nodeshiftDirectory || '.nodeshift';
+  options.nodeshiftDirectory = '.nodeshift';
   options.projectLocation = options.projectLocation || process.cwd();
 
   logger.info('loading configuration');

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "nodeshift": "./bin/nodeshift"
   },
   "scripts": {
-    "lint": "eslint bin/* lib/**/*.js test/**/*.js index.js",
+    "lint": "eslint bin/* lib/**/*.js test/*-test.js test/**/*-test.js index.js",
     "test": "NODESHIFT_QUIET=true tape test/*-test.js test/**/*-test.js | tap-spec",
     "prepublish": "nsp check",
     "coverage": "nyc npm test",

--- a/test/nodeshift-config-test.js
+++ b/test/nodeshift-config-test.js
@@ -41,13 +41,11 @@ test('nodeshift-config other project location and nodeshiftDir', (t) => {
   });
 
   const options = {
-    projectLocation: '../examples/sample-project',
-    nodeshiftDirectory: '.notnodeshift'
+    projectLocation: '../examples/sample-project'
   };
 
   nodeshiftConfig(options).then((config) => {
     t.equal(config.projectLocation, '../examples/sample-project', 'projectLocation prop should be changed');
-    t.equal(config.nodeshiftDirectory, '.notnodeshift', 'nodeshiftDir prop should be changed');
     t.end();
   });
 });

--- a/test/resource-loader-test.js
+++ b/test/resource-loader-test.js
@@ -41,7 +41,7 @@ test('test no .nodeshift directory using defaults', (t) => {
 test('test using different nodeshift and projectLocation', (t) => {
   const config = {
     projectLocation: 'not_default',
-    nodeshiftDirectory: 'mavenshift'
+    nodeshiftDirectory: '.nodeshift'
   };
 
   const mockedfs = {

--- a/test/resource-loader-test.js
+++ b/test/resource-loader-test.js
@@ -89,29 +89,6 @@ test('test only return .ymls or .yamls or .json', (t) => {
     yamlToJson: (file) => { return file; }
   };
 
-  const returnedFiles = [
-    {
-      type: 'yml',
-      filename: 'yml'
-    },
-    {
-      type: 'js',
-      filename: 'no'
-    },
-    {
-      type: 'yml',
-      filename: 'yes1'
-    },
-    {
-      type: 'yaml',
-      filename: 'yes3'
-    },
-    {
-      type: 'json',
-      filename: 'jsonyes'
-    }
-  ];
-
   const mockedfs = {
     readFile: (locations, options, cb) => {
       const parts = locations.split('/');


### PR DESCRIPTION
i don't think there is a need to have the `--nodeshiftDirectory` options.

this only changed the name of the directory, not the actual location.  