### PR TITLE
src: improve log message when user is not logged in

### DIFF
--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,11 +6,10 @@ const resourceGoal = require('../lib/goals/resource');
 const buildGoal = require('../lib/goals/build');
 const applyResources = require('../lib/apply-resources');
 const undeployGoal = require('../lib/goals/undeploy');
-let config;
 
 module.exports = async function run (options) {
   try {
-    config = await nodeshiftConfig(options);
+    const config = await nodeshiftConfig(options);
     let enrichedResources = {};
     if (options.cmd === 'resource' || options.cmd === 'deploy' || options.cmd === 'apply-resource') {
       enrichedResources = await resourceGoal(config);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -6,10 +6,11 @@ const resourceGoal = require('../lib/goals/resource');
 const buildGoal = require('../lib/goals/build');
 const applyResources = require('../lib/apply-resources');
 const undeployGoal = require('../lib/goals/undeploy');
+let config;
 
 module.exports = async function run (options) {
   try {
-    const config = await nodeshiftConfig(options);
+    config = await nodeshiftConfig(options);
     let enrichedResources = {};
     if (options.cmd === 'resource' || options.cmd === 'deploy' || options.cmd === 'apply-resource') {
       enrichedResources = await resourceGoal(config);

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -61,7 +61,10 @@ yargs
 function commandHandler (argv) {
   const options = createOptions(argv);
   require('./cli')(options).then(logger.info).catch((err) => {
-    logger.error(err, err.stack);
+    const log = require('../lib/common-log')();
+    log.error(err.message);
+    log.error('Status code', err.statusCode);
+    require('util').debuglog('nodeshift.cli')(err.stack);
     process.exit(1);
   });
 }


### PR DESCRIPTION
It's debatable whether this is a great improvement. I will adjust it
if it turns out to be not ideal. Now, when a user is not logged in,
the CLI writes the caught exception message and status code to
the output log. It would be ideal if we could determinen whether the
user was already logged in before making a remote call, however, so
that we can make the output nicer looking. In any case, here is what
the error looks like now.

```sh
~/s/nodejs-rest-http (master $=) nodeshift --osc.strictSSL=false .
2017-11-16T16:58:53.841Z INFO loading configuration
2017-11-16T16:58:53.867Z INFO using namespace myproject at https://192.168.99.100:8443
2017-11-16T16:58:53.871Z INFO enriching Deployment resource
2017-11-16T16:58:53.873Z INFO enriching Route resource
2017-11-16T16:58:53.874Z INFO enriching Service resource
2017-11-16T16:58:53.879Z INFO openshift.yaml and openshift.json written to /Users/lanceball/src/nodejs-rest-http/tmp/nodeshift/resource/
2017-11-16T16:58:53.883Z INFO creating archive of package.json, app.js, public, bin, LICENSE
2017-11-16T16:58:53.922Z ERROR User "system:anonymous" cannot get buildconfigs in project "myproject"
2017-11-16T16:58:53.922Z ERROR Status code 403
```

I also added debuglog for the CLI, so if the command is run as

```sh
$ NODE_DEBUG=nodeshift.cli nodeshift .
```

then it will print the stack ~~~and config object~~~ to the console.

Fixes: https://github.com/bucharest-gold/nodeshift/issues/98