### PR TITLE
src: return an object of metadata from oc calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,27 +167,38 @@ There are a few options available on the CLI or when using the API
 
         Commands:
             nodeshift deploy          default command - deploy                   [default]
-            nodeshift resource        resource command
             nodeshift build           build command
+            nodeshift resource        resource command
             nodeshift apply-resource  apply resource command
             nodeshift undeploy        undeploy resources
 
         Options:
-            --version             Show version number                            [boolean]
-            --projectLocation     change the default location of the project      [string]
-            --configLocation      change the default location of the config       [string]
-            --osc.strictSSL       setting to pass to the Openshift Rest Client. Set to
+            --version                Show version number                         [boolean]
+            --projectLocation        change the default location of the project   [string]
+            --configLocation         change the default location of the config    [string]
+            --osc.strictSSL          setting to pass to the Openshift Rest Client. Set to
                                     false if using a self-sign cert
-            --nodeVersion, -n     the version of Node.js to use for the deployed
+            --osl.tryServiceAccount  setting to pass to the Openshift Config Loader.
+                                    Set to false to by-pass service account lookup
+                                    or use the KUBERNETES_AUTH_TRYSERVICEACCOUNT
+                                    environment variable
+
+            --nodeVersion, -n        the version of Node.js to use for the deployed
                                     application.
-                [string] [choices: "latest", "8.x", "7.x", "6.x", "5.x", "4.x"] [default:
-                                                                                "latest"]
+                    [string] [choices: "latest", "9.x", "8.x", "7.x", "6.x", "5.x", "4.x"]
+                                                                        [default: "latest"]
+            --quiet                  supress INFO and TRACE lines from output logs
+                                                                                [boolean]
             --build.recreate         flag to recreate a buildConfig or Imagestream
-                [choices: "buildConfig", "imageStream", false, true] [default: false]
+                    [choices: "buildConfig", "imageStream", false, true] [default: false]
             --build.forcePull        flag to make your BuildConfig always pull a new image
-                                      from dockerhub or not
-                [boolean] [choices: true, false] [default: false]
-            --help                Show help                                      [boolean]
+                                    from dockerhub or not
+                                        [boolean] [choices: true, false] [default: false]
+            --metadata.out           determines what should be done with the response
+                                    metadata from OpenShift
+                    [string] [choices: "stdout", "ignore", "<filename>"] [default: "ignore"]
+            --help                   Show help                                   [boolean]
+            --cmd                                                      [default: "deploy"]
 
 
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -29,22 +29,29 @@ module.exports = async function run (options) {
   try {
     const config = await nodeshiftConfig(options);
     const response = {};
-    if (options.cmd === 'resource' || options.cmd === 'deploy' || options.cmd === 'apply-resource') {
-      const enrichedResources = await resourceGoal(config);
-      response.resources = enrichedResources;
-      if (options.cmd === 'deploy' || options.cmd === 'apply-resource') {
-        response.appliedResources = await applyResources(config, enrichedResources);
-      }
-    }
 
-    if (options.cmd === 'deploy' || options.cmd === 'build') {
-      response.build = await buildGoal(config);
+    switch (options.cmd) {
+      case 'build':
+        response.build = await buildGoal(config);
+        break;
+      case 'resource':
+        response.resources = await resourceGoal(config);
+        break;
+      case 'apply-resource':
+        response.resources = await resourceGoal(config);
+        response.appliedResources = await applyResources(config, response.resources);
+        break;
+      case 'undeploy':
+        response.undeploy = await undeployGoal(config);
+        break;
+      case 'deploy':
+        response.build = await buildGoal(config);
+        response.resources = await resourceGoal(config);
+        response.appliedResources = await applyResources(config, response.resources);
+        break;
+      default:
+        throw new TypeError(`Unexpected command: ${options.cmd}`);
     }
-
-    if (options.cmd === 'undeploy') {
-      response.undeploy = undeployGoal(config);
-    }
-
     return response;
   } catch (err) {
     return Promise.reject(err);

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -28,24 +28,24 @@ const undeployGoal = require('../lib/goals/undeploy');
 module.exports = async function run (options) {
   try {
     const config = await nodeshiftConfig(options);
-    let enrichedResources = {};
+    const response = {};
     if (options.cmd === 'resource' || options.cmd === 'deploy' || options.cmd === 'apply-resource') {
-      enrichedResources = await resourceGoal(config);
+      const enrichedResources = await resourceGoal(config);
+      response.resources = enrichedResources;
+      if (options.cmd === 'deploy' || options.cmd === 'apply-resource') {
+        response.appliedResources = await applyResources(config, enrichedResources);
+      }
     }
 
     if (options.cmd === 'deploy' || options.cmd === 'build') {
-      await buildGoal(config);
-    }
-
-    if (options.cmd === 'deploy' || options.cmd === 'apply-resource') {
-      await applyResources(config, enrichedResources);
+      response.build = await buildGoal(config);
     }
 
     if (options.cmd === 'undeploy') {
-      await undeployGoal(config);
+      response.undeploy = undeployGoal(config);
     }
 
-    return 'done';
+    return response;
   } catch (err) {
     return Promise.reject(err);
   }

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -23,8 +23,9 @@
 // Providing a title to the process in `ps`
 process.title = 'nodeshift'; // Thanks Ember-cli :)
 
+const fs = require('fs');
 const yargs = require('yargs');
-const logger = require('../lib/common-log')();
+const log = require('../lib/common-log')();
 
 /* eslint no-unused-expressions: "warn" */
 yargs
@@ -75,17 +76,33 @@ yargs
     type: 'boolean',
     default: false
   })
+  .options('metadata.out', {
+    describe: 'determines what should be done with the response metadata from OpenShift',
+    choices: ['stdout', 'ignore', '<filename>'],
+    type: 'string',
+    default: 'ignore'
+  })
   .help().argv;
 
 function commandHandler (argv) {
   const options = createOptions(argv);
-  require('./cli')(options).then(logger.info).catch((err) => {
-    const log = require('../lib/common-log')();
-    log.error(err.message);
-    log.error('Status code', err.statusCode);
-    require('util').debuglog('nodeshift.cli')(err.stack);
-    process.exit(1);
-  });
+  require('./cli')(options).then((response) => {
+    if (options.metadata) {
+      if (options.metadata.out === 'stdout') {
+        process.stdout.write(JSON.stringify(response, null, 2));
+      } else {
+        fs.writeFileSync(options.metadata.out, JSON.stringify(response, null, 2), 'utf8');
+      }
+    } else {
+      log.info('complete');
+    }
+  })
+    .catch((err) => {
+      log.error(err.message);
+      log.error('Status code', err.statusCode);
+      require('util').debuglog('nodeshift.cli')(err.stack);
+      process.exit(1);
+    });
 }
 
 function createOptions (argv) {
@@ -95,6 +112,7 @@ function createOptions (argv) {
   options.configLocation = argv.configLocation;
   options.nodeVersion = argv.nodeVersion;
   process.env['NODESHIFT_QUIET'] = argv.quiet === true;
+  options.metadata = argv.metadata;
   options.build = argv.build;
   options.cmd = argv.cmd;
 

--- a/lib/apply-resources.js
+++ b/lib/apply-resources.js
@@ -38,6 +38,5 @@ module.exports = (config, resourceList) => {
         return Promise.resolve(r);
     }
   });
-
   return Promise.all(mappedResources);
 };

--- a/lib/deployment-config.js
+++ b/lib/deployment-config.js
@@ -44,10 +44,13 @@ async function undeploy (config, deploymentConfigResource) {
       gracePeriodSeconds: undefined
     }
   };
+  const response = {
+    replicationControllers: []
+  };
 
   // then delete the deploymentconfig
   logger.info(`Deleteing Deployment Config ${deploymentConfigResource.metadata.name}`);
-  await config.openshiftRestClient.deploymentconfigs.remove(deploymentConfigResource.metadata.name, removeOptionsDeploymentConfig);
+  response.deploymentConfig = await config.openshiftRestClient.deploymentconfigs.remove(deploymentConfigResource.metadata.name, removeOptionsDeploymentConfig);
   // Get the list of replication controllers
   const rcList = await config.openshiftRestClient.replicationcontrollers.findAll({qs: {labelSelector: `openshift.io/deployment-config.name=${config.projectName}`}});
 
@@ -60,10 +63,11 @@ async function undeploy (config, deploymentConfigResource) {
   // Delete the builds that it finds
   for (const items of rcList.items) {
     logger.info(`Deleteing replication controller ${items.metadata.name}`);
-    await config.openshiftRestClient.replicationcontrollers.remove(items.metadata.name, removeOptionsReplicationControllers);
+    response.replicationControllers.push(
+      await config.openshiftRestClient.replicationcontrollers.remove(
+        items.metadata.name, removeOptionsReplicationControllers));
   }
-  // Delete them
-  return 'done';
+  return response;
 }
 
 module.exports = {

--- a/lib/goals/build.js
+++ b/lib/goals/build.js
@@ -37,8 +37,5 @@ module.exports = async function build (config) {
   await imageStreamConfigurator.createOrUpdateImageStream(config);
 
   // push to the cluster
-  await binaryBuild(config, `${config.projectLocation}/${dockerArchiver.DEFAULT_BUILD_LOCATION}/archive.tar`);
-
-  // TODO: provide something better?
-  return 'build complete';
+  return binaryBuild(config, `${config.projectLocation}/${dockerArchiver.DEFAULT_BUILD_LOCATION}/archive.tar`);
 };

--- a/lib/goals/undeploy.js
+++ b/lib/goals/undeploy.js
@@ -68,6 +68,5 @@ module.exports = async function (config) {
         logger.error(`${item.kind} is not recognized`);
     }
   }
-  console.error('response', response);
   return response;
 };

--- a/lib/goals/undeploy.js
+++ b/lib/goals/undeploy.js
@@ -47,27 +47,27 @@ module.exports = async function (config) {
       gracePeriodSeconds: undefined
     }
   };
+  const response = {};
   // Iterate through the list of items and delete the items
   for (const item of resourceList.items || []) {
+    logger.info(`removing ${item.kind} ${item.metadata.name}`);
     switch (item.kind) {
       case 'Route':
-        logger.info(`removing ${item.kind} ${item.metadata.name}`);
-        await config.openshiftRestClient.routes.remove(item.metadata.name, removeOptions);
+        response.route = await config.openshiftRestClient.routes.remove(item.metadata.name, removeOptions);
         break;
       case 'Service':
-        logger.info(`removing ${item.kind} ${item.metadata.name}`);
-        await config.openshiftRestClient.services.remove(item.metadata.name, removeOptions);
+        response.service = await config.openshiftRestClient.services.remove(item.metadata.name, removeOptions);
         break;
       case 'DeploymentConfig':
-        await deploymentConfig(config, item);
+        response.deploymentConfig = await deploymentConfig(config, item);
         break;
       case 'Secret':
-        logger.info(`removing ${item.kind} ${item.metadata.name}`);
-        await config.openshiftRestClient.secrets.remove(item.metadata.name, removeOptions);
+        response.secret = await config.openshiftRestClient.secrets.remove(item.metadata.name, removeOptions);
         break;
       default:
-        logger.warning(`${item.kind} is not recognized`);
+        logger.error(`${item.kind} is not recognized`);
     }
   }
-  return resourceList;
+  console.error('response', response);
+  return response;
 };

--- a/test/cli-test.js
+++ b/test/cli-test.js
@@ -101,7 +101,8 @@ test('no goal', (t) => {
     }
   });
 
-  cli({}).then(() => {
+  cli({}).catch((err) => {
+    t.equal(err.message, 'Unexpected command: undefined', 'should have this error message');
     t.end();
   });
 });


### PR DESCRIPTION
This change adds a new command line option, `--metadata.out` which can have three possible values `stdout`, `false` or `<filename>`. When specified as `stdout` or `<filename>` the returned `JSON` from the `oc` REST calls is written to the specified output location.

Fixes: https://github.com/bucharest-gold/nodeshift/issues/76

connects to #76 