### PR TITLE
fix: make --quiet flag work again

### DIFF
--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -25,7 +25,6 @@ process.title = 'nodeshift'; // Thanks Ember-cli :)
 
 const fs = require('fs');
 const yargs = require('yargs');
-const log = require('../lib/common-log')();
 
 /* eslint no-unused-expressions: "warn" */
 yargs
@@ -86,6 +85,7 @@ yargs
 
 function commandHandler (argv) {
   const options = createOptions(argv);
+  const log = require('../lib/common-log')();
   require('./cli')(options).then((response) => {
     if (options.metadata) {
       if (options.metadata.out === 'stdout') {


### PR DESCRIPTION
It's a timing thing. We can't `require()` the log until the options have been processed.

Fixes: https://github.com/bucharest-gold/nodeshift/issues/154
Connects to: https://github.com/bucharest-gold/nodeshift/issues/154