### PR TITLE
fix: make sure the pod is initialized first before trying to get the log

### DIFF
--- a/lib/binary-build.js
+++ b/lib/binary-build.js
@@ -36,7 +36,10 @@ module.exports = async (config, archiveLocation) => {
   logger.info('binary upload complete');
 
   // Trigger watch of build
-  const buildLogWatcher = watchBuildLog(config, response.metadata.name);
+  let buildLogWatcher;
+  setTimeout(() => {
+    buildLogWatcher = watchBuildLog(config, response.metadata.name);
+  }, 10);
 
   logger.info('waiting for build to finish');
   const MAX_RETRIES = 200;

--- a/lib/build-watcher.js
+++ b/lib/build-watcher.js
@@ -22,8 +22,50 @@ const request = require('request');
 const logger = require('./common-log')();
 // https://192.168.99.100:8443/api/v1/namespaces/node-demo-1/pods/wfswarm-rest-http-s2i-5-build/log?pretty=false&follow=true';
 
+function wait (timeout) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, timeout);
+  });
+}
+
+function podLogEndpoint (config, build) {
+  return new Promise((resolve, reject) => {
+    const req = {
+      url: `${config.openshiftRestClient.kubeUrl}/namespaces/${config.context.namespace}/pods/${build}-build/log`,
+      auth: {
+        bearer: config.user.token
+      },
+      strictSSL: config.strictSSL
+    };
+
+    request(req, (err, resp, body) => {
+      if (err) return reject(err);
+
+      return resolve(resp);
+    });
+  });
+}
+
+async function pingEndpoint (config, build) {
+  const MAX_RETRIES = 200;
+  for (let i = 0; i <= MAX_RETRIES; i++) {
+    const timeout = (i + 1) * 200;
+    await wait(timeout);
+
+    const response = await podLogEndpoint(config, build);
+
+    if (response.statusCode === 200) {
+      return response;
+    }
+  }
+}
+
 // Probably do this somewhere else eventually
-module.exports = function watchBuildLog (config, build) {
+module.exports = async function watchBuildLog (config, build) {
+  // Ping until we get a 200 response,
+  await pingEndpoint(config, build);
+  // Then do the follow endpoint
+
   return new Promise((resolve, reject) => {
     const req = {
       url: `${config.openshiftRestClient.kubeUrl}/namespaces/${config.context.namespace}/pods/${build}-build/log?pretty=false&follow=true`,


### PR DESCRIPTION
fixes #164 

Basically just pinging the pod log endpoint with a decay, then once we get a 200 response, we stream the log

connects to #164 