### PR TITLE
fix: label enricher should be called labels not label

### DIFF
--- a/lib/resource-enrichers/default-enrichers.json
+++ b/lib/resource-enrichers/default-enrichers.json
@@ -1,3 +1,3 @@
 [
-  "deployment-config", "services", "routes", "label", "git-info", "health-check"
+  "deployment-config", "services", "routes", "labels", "git-info", "health-check"
 ]


### PR DESCRIPTION
I forgot to undeploy my previous application when i was testing the enricher loader out, so when i finally did, i couldn't deploy since there was an error with the creation of the deployment config.

this fixes that.  doesn't affect 1.1.0,  just when doing the npm link to master