### PR TITLE
feat(config-loader): expose the configLocation options for the opensh…

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,9 @@ Changes the default location of where to look for your project. Defaults to your
 #### strictSSL
 This option is passed through to the [Openshift Rest Client](https://www.npmjs.com/package/openshift-rest-client) for SSL use.  To allow using a self-signed cert, set to false
 
+#### configLocation
+This option is passed through to the [Openshift Config Loader](https://www.npmjs.com/package/openshift-config-loader).  Defaults to the `~/.kube/config`
+
 #### tryServiceAccount
 This option is passed through to the [Openshift Config Loader](https://www.npmjs.com/package/openshift-config-loader). Set to false to by-pass service account lookup or use the KUBERNETES_AUTH_TRYSERVICEACCOUNT environment variable
 

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -41,6 +41,10 @@ yargs
   .options('strictSSL', {
     describe: 'setting to pass to the Openshift Rest Client. Set to false if using a self-sign cert'
   })
+  .option('configLocation', {
+    describe: 'change the default location of the config',
+    type: 'string'
+  })
   .options('tryServiceAccount', {
     describe: `setting to pass to the Openshift Config Loader. Set to false to by-pass service account lookup
     or use the KUBERNETES_AUTH_TRYSERVICEACCOUNT environment variable
@@ -119,6 +123,7 @@ function createOptions (argv) {
   options.removeAll = argv.removeAll;
   options.strictSSL = argv.strictSSL !== 'false';
   options.tryServiceAccount = argv.tryServiceAccount !== 'false';
+  options.configLocation = argv.configLocation;
 
   // Check for the -d array
   // If it is there, we need to parse it.

--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -33,7 +33,7 @@ async function setup (options = {}) {
 
   logger.info('loading configuration');
   const projectPackage = require(`${options.projectLocation}/package.json`);
-  const config = await openshiftConfigLoader(Object.assign({}, {tryServiceAccount: options.tryServiceAccount}));
+  const config = await openshiftConfigLoader(Object.assign({}, {tryServiceAccount: options.tryServiceAccount, configLocation: options.configLocation}));
   logger.info(`using namespace ${config.context.namespace} at ${config.cluster}`);
 
   // Return a new object with the config, the rest client and other data.

--- a/test/nodeshift-config-test.js
+++ b/test/nodeshift-config-test.js
@@ -100,6 +100,7 @@ test('nodeshift-config options for the config loader', (t) => {
   const nodeshiftConfig = proxyquire('../lib/nodeshift-config', {
     'openshift-config-loader': (options) => {
       t.ok(options.tryServiceAccount, 'tryServiceAccount should be there');
+      t.ok(options.configLocation, 'configLocation should be there');
       return Promise.resolve({
         context: {
           namespace: 'test-namespace'
@@ -117,6 +118,7 @@ test('nodeshift-config options for the config loader', (t) => {
 
   nodeshiftConfig(options).then((config) => {
     t.ok(config.tryServiceAccount, 'tryServiceAccount should be there');
+    t.ok(config.configLocation, 'configLocation should be there');
     t.end();
   });
 });


### PR DESCRIPTION
…ift-config-loader.

* This was previously taken out, but is needed again.
* use --configLocation on the cli or the options.configLocation in the API

fixes #197