### PR TITLE
fix(archiver): fix for source archiver when no files property is foun…

### DIFF
--- a/lib/docker-archiver.js
+++ b/lib/docker-archiver.js
@@ -40,9 +40,20 @@ async function createArchive (config) {
   } else {
     // If Not, then just use the current directory "./"
     logger.warning('a file property was not found in your package.json, archiving the current directory.');
-    includedFiles.push('./');
+    // Get the list of files and directories
+    const fileList = await helpers.listFiles('./');
+    // Push those into the includedFiles
+    const filteredOut = fileList.filter((file) => {
+      // exclude the node_modules and .git directories and tmp
+      if (file === 'node_modules' || file === '.git' || file === 'tmp') {
+        return false;
+      }
+
+      return true;
+    });
+
+    includedFiles.push.apply(includedFiles, filteredOut);
   }
-  // TODO: ignore tmp dirs and .git(?) directory, Make configurable to exclude more directories, Maybe just look at the package.json files prop?
   logger.info(`creating archive of ${includedFiles.join(', ')}`);
   await helpers.createDir(`${config.projectLocation}/${DEFAULT_BUILD_LOCATION}`);
   return tar.create({

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -22,6 +22,8 @@ const jsyaml = require('js-yaml');
 const fs = require('fs');
 const mkdirp = require('mkdirp');
 const rimraf = require('rimraf');
+const {promisify} = require('util');
+const readdir = promisify(fs.readdir);
 
 // Take yaml as a string that has already been loaded from a file or something.
 function yamlToJson (yamlToParse) {
@@ -69,9 +71,14 @@ function cleanUp (directoryToClean) {
   });
 }
 
+function listFiles (dir) {
+  return readdir(dir);
+}
+
 module.exports = {
   yamlToJson: yamlToJson,
   normalizeFileList: normalizeFileList,
   createDir: createDir,
-  cleanUp: cleanUp
+  cleanUp: cleanUp,
+  listFiles: listFiles
 };

--- a/test/docker-archiver-test.js
+++ b/test/docker-archiver-test.js
@@ -75,6 +75,40 @@ test('test error with create dir function', (t) => {
   });
 });
 
+test('test no file prop, exclude stuff', (t) => {
+  const dockerArchiver = proxyquire('../lib/docker-archiver', {
+    './helpers': {
+      createDir: () => {
+        return Promise.resolve();
+      },
+      cleanUp: () => {
+        return Promise.resolve();
+      },
+      listFiles: () => {
+        return Promise.resolve(['node_modules', '.git', 'tmp', 'file1', 'other']);
+      }
+    },
+    tar: {
+      create: (obj, files) => {
+        t.equal(files.length, 2, 'should only have 2 values');
+        t.ok(!files.includes('node_modules'), 'should not include node_modules');
+        t.ok(!files.includes('.git'), 'should not include .git');
+        t.ok(!files.includes('tmp'), 'should not include tmp');
+        return Promise.resolve();
+      }
+    }
+  });
+
+  const config = {
+    projectPackage: {}
+  };
+
+  dockerArchiver.archiveAndTar(config).then(() => {
+    t.pass('should resolve');
+    t.end();
+  });
+});
+
 test('test logger warning if no files prop', (t) => {
   const dockerArchiver = proxyquire('../lib/docker-archiver', {
     './helpers': {


### PR DESCRIPTION
…d in the package.json

* If no files property was found in the package.json, nodeshift would archive(tar) the current working directory.  When there was a node_modules folder in that directory, which usually happens, the archive would grow to a crazy size.

* The archiver has been updated to no longer include the node_modules, .git and tmp folders.

It is still recommeneded to use the files property though.

fixes #200

i think i still need to add some tests