### PR TITLE
feat(build.env): add a --build.env flag to specify build config envir…

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ Flag to recreate a BuildConfig or Imagestream.  Defaults to false. Choices are "
 #### build.forcePull
 Flag to make your BuildConfig always pull a new image from dockerhub.  Defaults to false
 
+#### build.env
+Flag to pass build config environment variables as NAME=Value.  Can be used multiple times.  ex: `nodeshift --build.env NODE_ENV=development --build.env YARN_ENABLED=true`
+
 #### help
 Shows the below help
 

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -26,6 +26,8 @@ process.title = 'nodeshift'; // Thanks Ember-cli :)
 const fs = require('fs');
 const yargs = require('yargs');
 
+const helpers = require('../lib/helpers');
+
 /* eslint no-unused-expressions: "warn" */
 yargs
   .usage('[--options]')
@@ -83,6 +85,7 @@ yargs
     type: 'boolean',
     default: false
   })
+  .array('build.env')
   .options('metadata.out', {
     describe: 'determines what should be done with the response metadata from OpenShift',
     choices: ['stdout', 'ignore', '<filename>'],
@@ -132,23 +135,18 @@ function createOptions (argv) {
   options.tryServiceAccount = argv.tryServiceAccount !== 'false';
   options.configLocation = argv.configLocation;
 
+  // Check for the --build.env array
+  // If it is there, we need to parse it
+  // The values should be in the format KEY=value
+  if (argv.build.env) {
+    options.build.env = helpers.parseMultiOption(argv.build.env);
+  }
+
   // Check for the -d array
   // If it is there, we need to parse it.
-  // The values should be in the format VALUE=key
+  // The values should be in the format KEY=value
   if (argv.d) {
-    const splitted = argv.d.map((props) => {
-      return props.split('=');
-    });
-
-    // convert our split array to an array of objects where the key is the 0 index and value is the 1 index
-    const definedProperties = splitted.map((v) => {
-      return {
-        key: v[0],
-        value: v[1]
-      };
-    });
-
-    options.definedProperties = definedProperties;
+    options.definedProperties = helpers.parseMultiOption(argv.d);
   } else {
     options.definedProperties = [];
   }

--- a/index.js
+++ b/index.js
@@ -22,6 +22,7 @@ const cli = require('./bin/cli');
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
+  @param {Array} [options.build.env] - an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
   @returns {Promise} - Returns a JSON Object
 */
@@ -106,6 +107,7 @@ function undeploy (options = {}) {
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
   @param {boolean} [options.build.forcePull] - flag to make your BuildConfig always pull a new image from dockerhub or not. Defaults to false
+  @param {Array} [options.build.env] - an array of objects to pass build config environment variables.  [{name: NAME_PROP, value: VALUE}]
   @param {array} [options.definedProperties] - Array of objects with the format { key: value }.  Used for template substitution
   @returns {Promise} - Returns a JSON Object
 */

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -93,7 +93,8 @@ async function createOrUpdateBuildConfig (config) {
       outputImageStreamTag: outputImageStreamTag,
       nodeVersion: config.nodeVersion,
       forcePull: config.build.forcePull,
-      dockerImage: config.dockerImage
+      dockerImage: config.dockerImage,
+      buildEnv: config.build.env
     });
     return config.openshiftRestClient.buildconfigs.create(newBuildConfig);
   }
@@ -109,7 +110,8 @@ async function createOrUpdateBuildConfig (config) {
       outputImageStreamTag: outputImageStreamTag,
       nodeVersion: config.nodeVersion,
       forcePull: config.build.forcePull,
-      dockerImage: config.dockerImage
+      dockerImage: config.dockerImage,
+      buildEnv: config.build.env
     });
     return config.openshiftRestClient.buildconfigs.create(newBuildConfig);
   }

--- a/lib/definitions/build-strategy.js
+++ b/lib/definitions/build-strategy.js
@@ -31,9 +31,11 @@ module.exports = (options = {}) => {
   const dockerTag = options.nodeVersion ? options.nodeVersion : DEFAULT_DOCKER_TAG;
   logger.info(`Using s2i image ${dockerImage} with tag ${dockerTag}`);
   const dockerImageName = `${dockerImage}:${dockerTag}`;
+  const env = options.buildEnv || [];
   return {
     type: 'Source',
     sourceStrategy: {
+      env: env,
       from: {
         kind: 'DockerImage',
         name: dockerImageName

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -75,10 +75,23 @@ function listFiles (dir) {
   return readdir(dir);
 }
 
+function parseMultiOption (arr) {
+  // split on the "=" then convert an array of objects where the name is the 0 index and value is the 1 index
+  return arr.map((props) => {
+    return props.split('=');
+  }).map((v) => {
+    return {
+      name: v[0],
+      value: v[1]
+    };
+  });
+}
+
 module.exports = {
   yamlToJson: yamlToJson,
   normalizeFileList: normalizeFileList,
   createDir: createDir,
   cleanUp: cleanUp,
-  listFiles: listFiles
+  listFiles: listFiles,
+  parseMultiOption: parseMultiOption
 };

--- a/lib/resource-loader.js
+++ b/lib/resource-loader.js
@@ -108,7 +108,7 @@ function loadFiles (resourceList, config) {
     const stringJSON = JSON.stringify(loadedResource);
     /* eslint prefer-template: "off" */
     const reduced = config.definedProperties.reduce((acc, curr) => {
-      return acc.split('${' + curr.key + '}').join(curr.value);
+      return acc.split('${' + curr.name + '}').join(curr.value);
     }, stringJSON);
     const backToJSON = JSON.parse(reduced);
 

--- a/test/definitions-tests/build-strategy-test.js
+++ b/test/definitions-tests/build-strategy-test.js
@@ -37,3 +37,19 @@ test('strategy with change dockerImage', (t) => {
   t.equal(result.sourceStrategy.from.name, 'lholmquist/centos7-s2i-nodejs:latest', 'docker image should be latet lholmquist image');
   t.end();
 });
+
+test('strategy with env vars', (t) => {
+  const envs = [
+    {
+      name: 'NODE_ENV',
+      value: 'development'
+    }
+  ];
+
+  const result = buildStrategy({buildEnv: envs});
+
+  t.ok(result.sourceStrategy.env, 'env prop exists');
+  t.equal(result.sourceStrategy.env[0].name, 'NODE_ENV', 'has the name value');
+  t.equal(result.sourceStrategy.env[0].value, 'development', 'has the value value');
+  t.end();
+});

--- a/test/helpers-test.js
+++ b/test/helpers-test.js
@@ -73,3 +73,21 @@ test('test cleanUp function - fail', (t) => {
     t.end();
   });
 });
+
+test('test parseMultiOption function', (t) => {
+  const helpers = require('../lib/helpers');
+  const arrayOfOptions = [
+    'NODE_ENV=development',
+    'YARN_ENABLED=true',
+    'KEY'
+  ];
+  const parsed = helpers.parseMultiOption(arrayOfOptions);
+
+  t.equal(Array.isArray(parsed), true, 'should return an array');
+  t.equal(parsed.length, 3, 'should return an array of lenght 3');
+  t.equal(parsed[0].name, 'NODE_ENV', 'first array with name prop');
+  t.equal(parsed[0].value, 'development', 'first array wih value');
+  t.equal(parsed[1].name, 'YARN_ENABLED', 'second array with name prop');
+  t.equal(parsed[1].value, 'true', 'second array wih value');
+  t.end();
+});

--- a/test/resource-loader-test.js
+++ b/test/resource-loader-test.js
@@ -286,7 +286,7 @@ test('test string substitution', (t) => {
     context: {
       namespace: 'my namespace'
     },
-    definedProperties: [{key: 'SSO_AUTH_SERVER_URL', value: 'https://yea'}]
+    definedProperties: [{name: 'SSO_AUTH_SERVER_URL', value: 'https://yea'}]
   };
 
   resourceLoader(config).then((resourceList) => {


### PR DESCRIPTION
…onment variables

* can be used multiple times like 'nodeshift --build.env NODE_ENV=development --build.env YARN_ENABLED=true'

fixes #208