### PR TITLE
add package name sanitisation

### DIFF
--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -112,7 +112,11 @@ function commandHandler (argv) {
   })
     .catch((err) => {
       log.error(err.message);
-      log.error('Status code', err.statusCode);
+
+      if (err && err.statusCode) {
+        log.error('Status code', err.statusCode);
+      }
+
       require('util').debuglog('nodeshift.cli')(err.stack);
       process.exit(1);
     });

--- a/lib/nodeshift-config.js
+++ b/lib/nodeshift-config.js
@@ -36,6 +36,10 @@ async function setup (options = {}) {
   const config = await openshiftConfigLoader(Object.assign({}, {tryServiceAccount: options.tryServiceAccount, configLocation: options.configLocation}));
   logger.info(`using namespace ${config.context.namespace} at ${config.cluster}`);
 
+  if (!projectPackage.name.match(/^[a-z][0-9a-z-]+[0-9a-z]$/)) {
+    throw new Error('"name" in package.json can only consist lower-case letters, numbers, and dashes. It must start with a letter and can\'t end with a -.');
+  }
+
   // Return a new object with the config, the rest client and other data.
   return Object.assign({}, config, {
     projectPackage,


### PR DESCRIPTION
Attempting to deploy an application that fails to meet openshift's
naming rules will result in misleading error messages being returned.

This commit addresses the issue by verifying the package.name is
compliant with openshift's naming restrictions.

See issue #211 