### PR TITLE
fix: add a name (http) to the service port

### DIFF
--- a/lib/resource-enrichers/service-enricher.js
+++ b/lib/resource-enrichers/service-enricher.js
@@ -44,12 +44,12 @@ function defaultService (config) {
     provider: 'nodeshift'
   };
 
-  // TODO: verify the ports property/add the ports property if missing?
   serviceConfig.spec.ports = [
     {
       protocol: 'TCP',
       port: config.port,
-      targetPort: config.port
+      targetPort: config.port,
+      name: 'http'
     }
   ];
 

--- a/test/enricher-tests/service-enricher-test.js
+++ b/test/enricher-tests/service-enricher-test.js
@@ -70,5 +70,6 @@ test('service enricher test - service', async (t) => {
   t.ok(Array.isArray(se[0].spec.ports), 'ports prop should be here');
   t.ok(se[0].spec.type, 'type prop should be here');
   t.equal(se[0].spec.type, 'ClusterIP', 'spec.type should be ClusterIP');
+  t.equal(se[0].spec.ports[0].name, 'http');
   t.end();
 });


### PR DESCRIPTION
I'm not sure if we should provide a configuration option for this or not. I'm also not sure what the behavior would be if some other value was already specified in a `.nodeshift/service.yml` file.


fixes #183 