### PR TITLE
feat: add the imageTag flag.

### DIFF
--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -59,8 +59,7 @@ yargs
   .options('nodeVersion', {
     describe: 'DEPRECATED - use imageTag instead.  The version of Node.js to use for the deployed application.',
     alias: 'n',
-    type: 'string',
-    default: 'latest'
+    type: 'string'
   })
   .options('imageTag', {
     describe: 'The version of the docker image to use for the deployed application.',

--- a/bin/nodeshift
+++ b/bin/nodeshift
@@ -57,8 +57,13 @@ yargs
     type: 'string'
   })
   .options('nodeVersion', {
-    describe: 'the version of Node.js to use for the deployed application.',
+    describe: 'DEPRECATED - use imageTag instead.  The version of Node.js to use for the deployed application.',
     alias: 'n',
+    type: 'string',
+    default: 'latest'
+  })
+  .options('imageTag', {
+    describe: 'The version of the docker image to use for the deployed application.',
     type: 'string',
     default: 'latest'
   })
@@ -142,7 +147,13 @@ function createOptions (argv) {
 
   options.projectLocation = argv.projectLocation;
   options.dockerImage = argv.dockerImage;
-  options.nodeVersion = argv.nodeVersion;
+  options.imageTag = argv.imageTag;
+  // Remove during a major version release
+  if (argv.nodeVersion) {
+    console.log('DEPRECATION NOTICE - nodeVersion will be removed in the 2.0 release of Nodeshift. Please use imageTag instead.');
+    options.imageTag = argv.nodeVersion;
+  }
+  //
   process.env['NODESHIFT_QUIET'] = argv.quiet === true;
   options.metadata = argv.metadata;
   options.build = argv.build;

--- a/index.js
+++ b/index.js
@@ -18,7 +18,8 @@ const cli = require('./bin/cli');
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
@@ -45,7 +46,8 @@ function deploy (options = {}) {
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false
@@ -67,7 +69,8 @@ function resource (options = {}) {
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {boolean} [options.expose] - Set to true to create a default Route and expose the default service.  defaults to false
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.deploy] -
   @param {number} [options.deploy.port] - flag to update the default ports on the resource files. Defaults to 8080
@@ -91,7 +94,8 @@ function applyResource (options = {}) {
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {boolean} [options.removeAll] - option to remove builds, buildConfigs and Imagestreams.  Defaults to false
   @param {object} [options.deploy] -
@@ -116,7 +120,8 @@ function undeploy (options = {}) {
   @param {boolean} [options.strictSSL] - Set to false to allow self-signed Certs
   @param {boolean} [options.tryServiceAccount] - Set to false to by-pass service account lookup
   @param {string} [options.namespace] - Overwrites any namespace settings in your OpenShift or Kubernetes configuration files
-  @param {string} [options.nodeVersion] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.nodeVersion(deprecated)] - set the nodeversion to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
+  @param {string} [options.imageTag] - set the version to use for the bucharest-gold/centos7-s2i-image.  Versions are docker hub tags: https://hub.docker.com/r/bucharestgold/centos7-s2i-nodejs/tags/
   @param {boolean} [options.quiet] - supress INFO and TRACE lines from output logs
   @param {object} [options.build] -
   @param {string/boolean} [options.build.recreate] - flag to recreate a buildConfig or Imagestream. values are "buildConfig", "imageStream", true, false.  Defaults to false

--- a/lib/build-config.js
+++ b/lib/build-config.js
@@ -91,7 +91,7 @@ async function createOrUpdateBuildConfig (config) {
     logger.info(`creating build configuration ${buildName}`);
     const newBuildConfig = createBuildConfig(config, {
       outputImageStreamTag: outputImageStreamTag,
-      nodeVersion: config.nodeVersion,
+      imageTag: config.imageTag,
       forcePull: config.build.forcePull,
       incremental: config.build.incremental,
       dockerImage: config.dockerImage,
@@ -109,7 +109,7 @@ async function createOrUpdateBuildConfig (config) {
     logger.info(`Re-creating build configuration ${buildName}`);
     const newBuildConfig = createBuildConfig(config, {
       outputImageStreamTag: outputImageStreamTag,
-      nodeVersion: config.nodeVersion,
+      imageTag: config.imageTag,
       forcePull: config.build.forcePull,
       dockerImage: config.dockerImage,
       buildEnv: config.build.env

--- a/lib/definitions/build-strategy.js
+++ b/lib/definitions/build-strategy.js
@@ -28,7 +28,8 @@ const DEFAULT_DOCKER_TAG = 'latest';
 module.exports = (options = {}) => {
   // Just doing the source strategy
   const dockerImage = options.dockerImage ? options.dockerImage : DEFAULT_DOCKER_IMAGE;
-  const dockerTag = options.nodeVersion ? options.nodeVersion : DEFAULT_DOCKER_TAG;
+  // remove the options.nodeVersion in 2.0
+  const dockerTag = options.imageTag ? options.imageTag : (options.nodeVersion ? options.nodeVersion : DEFAULT_DOCKER_TAG);
   logger.info(`Using s2i image ${dockerImage} with tag ${dockerTag}`);
   const dockerImageName = `${dockerImage}:${dockerTag}`;
   const env = options.buildEnv || [];

--- a/test/build-strategy-test.js
+++ b/test/build-strategy-test.js
@@ -12,3 +12,9 @@ test('accepts a node version option', t => {
   t.equals(buildStrategy.sourceStrategy.from.name, 'bucharestgold/centos7-s2i-nodejs:8.x');
   t.end();
 });
+
+test('accepts a node version using imageTag option', t => {
+  const buildStrategy = BuildStrategy({imageTag: '8.x'});
+  t.equals(buildStrategy.sourceStrategy.from.name, 'bucharestgold/centos7-s2i-nodejs:8.x');
+  t.end();
+});


### PR DESCRIPTION
This also deprecates the use of the --nodeVersion flag, which will be removed in the 2.0 version.

fixes #256